### PR TITLE
Fix package import when numba is not installed

### DIFF
--- a/esa/_performance_jit.py
+++ b/esa/_performance_jit.py
@@ -45,4 +45,4 @@ if use_numba:  # pragma: no cover
     calculate_bound = nb.njit()(_calculate_bound)
 else:  # pragma: no cover
     initialize_bound = _initialize_bound
-    calculate_bound = nb.njit()(_calculate_bound)
+    calculate_bound = _calculate_bound


### PR DESCRIPTION
When `numba` is not installed, the `calculate_bound` erroneously references the `nb` package, which does not exist. This PR instead falls back to the builtin `_calculate_bound` implementation which does not require numba.